### PR TITLE
Issue #8, 17 resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Hello, we are potato team!

--- a/potato.py
+++ b/potato.py
@@ -331,6 +331,29 @@ def run(mk, rm, mod, find, det, pg, p_opt):
     elif p_opt:
         print_option = p_opt
 
+    # cur.execute("select * from todo where 1")
+    # rows = cur.fetchall()
+
+    # if rows:
+    #     for row in rows:
+    #         iregular = re.compile(r"(\d{4})[-](\d{2})[-](\d{2})\s(\d{2})[:](\d{2})")
+    #         iregular2 = re.compile(r"(\d{4})[-](\d{2})[-](\d{2})\s(\d{2})[:](\d{2})")
+
+    #         idue = row[2]
+    #         i_match = iregular.match(idue)
+
+    #         t = datetime.datetime.now()
+    #         now = iregular2.match(str(t))
+
+    #         for i in range(1,6):
+    #             if int(i_match.group(i)) < int(now.group(i)):
+    #                 sql = "delete from todo where due = ?"
+
+    #                 cur.execute(sql, (i_match.group(0)))
+    #                 conn.commit()
+    #             elif int(i_match.group(i)) > int(now.group(i)):
+    #                 break
+
     print_list(pg, print_option)
     conn.close()
 

--- a/potato.py
+++ b/potato.py
@@ -75,39 +75,57 @@ def print_list(p_opt):
     cur.execute(check_print_option(p_opt))
     rows = cur.fetchall()
 
+    """Page settings"""
+
+    #Rows in single page
+    rows_in_pg = 10
+    #Rows in last page
+    rows_in_lpg = len(rows) % rows_in_pg
+    #Maximum page number
+    max_pg = int(len(rows) / rows_in_pg) if rows_in_lpg == 0 else len(rows) // rows_in_pg + 1
+
+
     if rows:
+        print(max_pg)
+        for page in range(0, max_pg):
+            print(
+                    "\n"
+                    "               P O T A T O F I E L D               \n"
+                    "===================================================\n"
+                    "| No.|   Description   |    Due     |   Status    |\n"
+                    "==================================================="
+                    )
 
-        print(
-            "\n"
-            "               P O T A T O F I E L D               \n"
-            "===================================================\n"
-            "| No.|   Description   |    Due     |   Status    |\n"
-            "==================================================="
-            )
+            count = 1
+            for row in rows[page * rows_in_pg:]:
 
-        for row in rows:
 
-            #Get the columns
-            num = row[0]
-            wh = row[1]
-            du = row[2]
-            fin = row[3]
+                #Get the columns
+                num = row[0]
+                wh = row[1]
+                du = row[2]
+                fin = row[3]
+
+                print(
+                    #Print the number of plan; Max : 2-digit number
+                    "|", str(num).ljust(2),
+                    #Print @#$^... if the description is too long to print; Max : 15 chars
+                    "|", wh.ljust(15) if len(wh)<=15 else wh[:12] + "...",
+                    #Print the due as it is since the due has its own format; YYYY-MM-DD
+                    "|", du,
+                    #Print whether the plan is done or not
+                    "| Done        |" if fin==1 else "| In progress |"
+                    )
+
+                count += 1
+
+                if count == rows_in_pg + 1:    break
 
             print(
-                #Print the number of plan; Max : 2-digit number
-                "|", str(num).ljust(2),
-                #Print @#$^... if the description is too long to print; Max : 15 chars
-                "|", wh.ljust(15) if len(wh)<=15 else wh[:12] + "...",
-                #Print the due as it is since the due has its own format; YYYY-MM-DD
-                "|", du,
-                #Print whether the plan is done or not
-                "| Done        |" if fin==1 else "| In progress |"
-                )
-
-        print(
-            "===================================================\n"
-            #Dummy line, but planning to make pages
-            "                                        Page 01/01 \n")
+                "===================================================\n"
+                "                                        Page"
+                "0" + str(page+1) if len(str(page)) == 1 else page
+                ,"/" + str(max_pg))
 
     else:
         print("Nothing to print :(\n")

--- a/potato.py
+++ b/potato.py
@@ -15,7 +15,7 @@ def create_db():
                 id integer primary key autoincrement,
                 what text not null,
                 due text not null,
-                category text,
+                category text not null,
                 finished integer default 0);"""
     
     cur.execute(table_create_sql)

--- a/potato.py
+++ b/potato.py
@@ -75,17 +75,42 @@ def print_list(p_opt):
     cur.execute(check_print_option(p_opt))
     rows = cur.fetchall()
 
-    print("")
     if rows:
+
+        print(
+            "\n"
+            "               P O T A T O F I E L D               \n"
+            "===================================================\n"
+            "| No.|   Description   |    Due     |   Status    |\n"
+            "==================================================="
+            )
+
         for row in rows:
-            for n in range(0,4):
-                if(n<3):
-                    print(" | " + str(row[n]), end="")
-                else:
-                    print(" | Done |" if row[3]==1 else " | In progress |", end="")
-            print("")
+
+            #Get the columns
+            num = row[0]
+            wh = row[1]
+            du = row[2]
+            fin = row[3]
+
+            print(
+                #Print the number of plan; Max : 2-digit number
+                "|", str(num).ljust(2),
+                #Print @#$^... if the description is too long to print; Max : 15 chars
+                "|", wh.ljust(15) if len(wh)<=15 else wh[:12] + "...",
+                #Print the due as it is since the due has its own format; YYYY-MM-DD
+                "|", du,
+                #Print whether the plan is done or not
+                "| Done        |" if fin==1 else "| In progress |"
+                )
+
+        print(
+            "===================================================\n"
+            #Dummy line, but planning to make pages
+            "                                        Page 01/01 \n")
+
     else:
-        print("Nothing to print :(")
+        print("Nothing to print :(\n")
 
 @click.command()
 #Basic options

--- a/potato.py
+++ b/potato.py
@@ -1,0 +1,117 @@
+import sqlite3
+import click
+
+def create_db():
+
+    global conn, cur
+
+    conn = sqlite3.connect("potato.db")
+    cur = conn.cursor()
+
+    table_create_sql = """create table if not exists todo (
+                id integer primary key autoincrement,
+                what text not null,
+                due text not null,
+                finished integer default 0);"""
+    
+    cur.execute(table_create_sql)
+
+def exe_mk(mk):
+
+    sql = "insert into todo (what, due) values (?, ?)"
+    task = mk
+
+    cur.execute(sql, task)
+    conn.commit()
+
+def exe_rm(rm):
+
+    sql = "delete from todo where id=?"
+    task = (rm,)
+
+    cur.execute(sql, task)
+    conn.commit()
+
+def exe_mod(mod):
+
+    cur.execute("select * from todo where id=?", (mod,))
+    row = cur.fetchall()
+
+    if row:
+        print("\n(Nothing will change if you enter nothing.)")
+        wh = str(input("What's your new plan?: "))
+        du = str(input("When is the due date? : "))
+        fin = str(input("Is it finished?(Y/N) : "))
+        while(fin != 'Y' and fin != 'N'):
+            fin = str(input('Is it finished?(Y/N) : '))
+        fin = 1 if fin == "Y" else 0
+
+        #Check if inputs are empty; nothing will change if input is empty
+        wh = wh if wh else row[0][1]
+        du = du if du else row[0][2]
+
+        sql = "update todo set what=?, due=?, finished=? where id=?"
+        task = (wh, du, fin, mod)
+
+        cur.execute(sql, task)
+        conn.commit()
+
+    else:
+    	print("\nInvalid number; check it again! :(")
+
+def check_print_option(p_opt):
+
+    default = "select * from todo where 1"
+
+    return{
+
+    'unfinished': "select * from todo where finished=0",
+    'finished': "select * from todo where finished=1"
+
+    }.get(p_opt, default)
+
+def print_list(p_opt):
+
+    cur.execute(check_print_option(p_opt))
+    rows = cur.fetchall()
+
+    print("")
+    if rows:
+        for row in rows:
+            for n in range(0,4):
+                if(n<3):
+                    print(" | " + str(row[n]), end="")
+                else:
+                    print(" | Done |" if row[3]==1 else " | In progress |", end="")
+            print("")
+    else:
+        print("Nothing to print :(")
+
+@click.command()
+#Basic options
+@click.option('--mk', nargs=2, type=str, help='Make a new plan: [descr.] [due]')
+@click.option('--rm', type=int, help='Remove your plan: [number]')
+@click.option('--mod', type=int, help='Modify your plan: [number]')
+#Printing options
+@click.option('--uf', 'p_opt', flag_value='unfinished', help='Print your unfinished plans')
+@click.option('--f', 'p_opt', flag_value='finished', help='Print your finished plans')
+def run(mk, rm, mod, p_opt):
+
+    create_db()
+    print_option = None
+
+    #Check the option
+    if mk:
+        exe_mk(mk)
+    elif rm:
+        exe_rm(rm)
+    elif mod:
+        exe_mod(mod)
+    elif p_opt:
+        print_option = p_opt
+
+    print_list(print_option)
+    conn.close()
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
#17 
기존의 카테고리는 불필요하거나 잘못된 라인-실행이 너무 많았습니다. 이를 수정하기 위해 많은 변경사항들이 있었습니다.
1.기존의 변수명인 ctg를 cat으로 변경했습니다. 카테고리를 줄여서 쓸 때는 ctg보단 cat을 주로 씁니다.
2.—cp 옵션과 —ctg옵션을 삭제하고, —cat옵션을 추가했습니다. 이 옵션은 p_opt parameter를 공유하는 boolean flag이면서 --cp와 --ctg 두 옵션의 기능을 전부 해냅니다.
3.이제 카테고리와 관련된 함수는 딱 자기 역할만 하고, 리스트를 프린트할 때는 반드시 check_print_option과 print_list를 이용합니다.

find또한 약간의 변경사항이 있습니다.
find는 다른 옵션들과는 약간 다른 케이스입니다. 따라서 알고리즘은 그대로 놔둔 상태에서 추가적으로 결과값을 출력해주는 함수 print_find_result를 추가했고, 그 결과값에서 자세한 내용을 볼 수 있게 해주는 함수 print_detail을 추가했습니다. (이 함수는 --det 옵션을 통해 따로 호출할 수도 있습니다.)

이외에도 문구나 프린트 형식을 변경한 부분들이 있습니다. 다만 이런 것들은 계속해서 조정해나갈 예정이기 때문에 크게 상관은 없다고 생각합니다.

#8 도 해결했습니다. 설명은 생략하겠습니다.